### PR TITLE
Adapt to Node conventions

### DIFF
--- a/lib/express-recaptcha.js
+++ b/lib/express-recaptcha.js
@@ -12,8 +12,8 @@ function Recaptcha(){
       next();
     },
     verify: function(req,res,next){
-      self.verify(req,function(success,error){
-        req.recaptcha = {success:success,error:error};
+      self.verify(req,function(error){
+        req.recaptcha = {error:error};
         next();
       });
     }
@@ -61,11 +61,11 @@ Recaptcha.prototype.verify = function(req, cb){
     res.on('end', function() {
       var result = JSON.parse(body);
       var error = result['error-codes'] && result['error-codes'].length > 0 ? result['error-codes'][0] : 'invalid-input-response';
-      if (result.success) cb(true,null);
-      else cb(false, error);
+      if (result.success) cb(null);
+      else cb(error);
     });
     res.on('error', function(e) {
-      cb(false,e.message);
+      cb(e.message);
     })
   });
 };


### PR DESCRIPTION
All core Node functions and many other popular community modules (mongoose) use `function (error)` for callback.

If `error` is `null`, it is assumed that function worked correctly without any problems. This PR will adapt to this Node convention.

Since we don't have any real data for the verify function, there is no need for `success` as a second parameter.

Users can check if Recaptcha worked by doing `if (!err)`