### PR TITLE
Optional custom host

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,27 +52,19 @@ var recaptcha = new Recaptcha('SITE_KEY', 'SECRET_KEY', options)
 
 #### `options` available/properties:
 
-| option          | description                                                                                                                                                                        |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `onload`        | The callback function that gets called when all the dependencies have loaded.                                                                                                      |
-| `hl`            | Forces the widget to render in a specific language (Auto-detects if unspecified).                                                                                                  |
-| `callback`      | In that callback you will call your backend to verify the given token. To be verified, the token needs to be posted with the key **g-recaptcha-response** (see the example folder) |
-| `action`        | **homepage** by default should only be alphanumeric [More info on google's web site](Google-recaptcha-action)                                                                      |
-| `checkremoteip` | Adding support of remoteip verification (based on x-forwarded-for header or remoteAddress.Value could be **true** OR **false** (default **false**).                                |
+| option               | description                                                                                                                                                                                                                   |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `onload`             | The callback function that gets called when all the dependencies have loaded.                                                                                                                                                 |
+| `hl`                 | Forces the widget to render in a specific language (Auto-detects if unspecified).                                                                                                                                             |
+| `callback`           | In that callback you will call your backend to verify the given token. To be verified, the token needs to be posted with the key **g-recaptcha-response** (see the example folder)                                            |
+| `action`             | **homepage** by default should only be alphanumeric [More info on google's web site](Google-recaptcha-action)                                                                                                                 |
+| `checkremoteip`      | Adding support of remoteip verification (based on x-forwarded-for header or remoteAddress.Value could be **true** OR **false** (default **false**).                                                                           |
+| `useRecaptchaDomain` | Boolean. Sets `www.recaptcha.net` as the host; useful in instances where `www.google.com` may be blocked (as detailed in the [reCaptcha docs](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally)) |
 
 **For more information, please refer to:**
 
 -   [reCaptcha - display](https://developers.google.com/recaptcha/docs/display#config)
 -   [reCaptcha - verify ](https://developers.google.com/recaptcha/docs/verify)
-
-#### Alternate host
-
-To use the alternate host `www.recaptcha.net` from which to serve reCaptcha assets (such as `api.js`), set the `alternate_host` argument to `true`:
-```
-var recaptcha = new Recaptcha('SITE_KEY', 'SECRET_KEY', options, true)
-```
-
-This is useful in instances where `www.google.com` may be blocked (as detailed here https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally)
 
 ### Render - `recaptcha.middleware.render`
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ var recaptcha = new Recaptcha('SITE_KEY', 'SECRET_KEY', options)
 
 #### Alternate host
 
-To provide an alternate host from which to serve reCaptcha assets (such as `api.js`), use the `CUSTOM_HOST` option:
+To use the alternate host `www.recaptcha.net` from which to serve reCaptcha assets (such as `api.js`), set the `alternate_host` argument to `true`:
 ```
-var recaptcha = new Recaptcha('SITE_KEY', 'SECRET_KEY', options, 'CUSTOM_HOST')
+var recaptcha = new Recaptcha('SITE_KEY', 'SECRET_KEY', options, true)
 ```
 
-This is useful in instances such as where `www.google.com` may be blocked and `www.recaptcha.net` could be used as the host instead (as detailed here https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally)
+This is useful in instances where `www.google.com` may be blocked (as detailed here https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally)
 
 ### Render - `recaptcha.middleware.render`
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ var recaptcha = new Recaptcha('SITE_KEY', 'SECRET_KEY', options)
 -   [reCaptcha - display](https://developers.google.com/recaptcha/docs/display#config)
 -   [reCaptcha - verify ](https://developers.google.com/recaptcha/docs/verify)
 
+#### Alternate host
+
+To provide an alternate host from which to serve reCaptcha assets (such as `api.js`), use the `CUSTOM_HOST` option:
+```
+var recaptcha = new Recaptcha('SITE_KEY', 'SECRET_KEY', options, 'CUSTOM_HOST')
+```
+
+This is useful in instances such as where `www.google.com` may be blocked and `www.recaptcha.net` could be used as the host instead (as detailed here https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally)
+
 ### Render - `recaptcha.middleware.render`
 
 The middleware's render method sets the `recaptcha` property of `res` object, with the generated html code. Therefore, you can easily append recaptcha into your templates by passing `res.recaptcha` to the view:

--- a/README.v2.md
+++ b/README.v2.md
@@ -60,18 +60,19 @@ var Recaptcha = require('express-recaptcha')
 
 #### `options` available/properties:
 
-| option             | description                                                                                                                                         |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `onload`           | The callback function that gets called when all the dependencies have loaded.                                                                       |
-| `render`           | Value could be **explicit** OR **onload**, Whether to render the widget explicitly.                                                                 |
-| `hl`               | Forces the widget to render in a specific language (Auto-detects if unspecified).                                                                   |
-| `theme`            | Value could be **dark** OR **light**, The color theme of the widget (default light).                                                                |
-| `type`             | Value could be **audio** OR **image**, The type of CAPTCHA to serve.                                                                                |
-| `callback`         | Your callback function that's executed when the user submits a successful CAPTCHA response.                                                         |
-| `expired_callback` | Your callback function that's executed when the recaptcha response expires and the user needs to solve a new CAPTCHA.                               |
-| `size`             | The size of the widget.                                                                                                                             |
-| `tabindex`         | The tabindex of the widget and challenge. If other elements in your page use tabindex, it should be set to make user navigation easier.             |
-| `checkremoteip`    | Adding support of remoteip verification (based on x-forwarded-for header or remoteAddress.Value could be **true** OR **false** (default **false**). |
+| option               | description                                                                                                                                                                                                                   |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `onload`             | The callback function that gets called when all the dependencies have loaded.                                                                                                                                                 |
+| `render`             | Value could be **explicit** OR **onload**, Whether to render the widget explicitly.                                                                                                                                           |
+| `hl`                 | Forces the widget to render in a specific language (Auto-detects if unspecified).                                                                                                                                             |
+| `theme`              | Value could be **dark** OR **light**, The color theme of the widget (default light).                                                                                                                                          |
+| `type`               | Value could be **audio** OR **image**, The type of CAPTCHA to serve.                                                                                                                                                          |
+| `callback`           | Your callback function that's executed when the user submits a successful CAPTCHA response.                                                                                                                                   |
+| `expired_callback`   | Your callback function that's executed when the recaptcha response expires and the user needs to solve a new CAPTCHA.                                                                                                         |
+| `size`               | The size of the widget.                                                                                                                                                                                                       |
+| `tabindex`           | The tabindex of the widget and challenge. If other elements in your page use tabindex, it should be set to make user navigation easier.                                                                                       |
+| `checkremoteip`      | Adding support of remoteip verification (based on x-forwarded-for header or remoteAddress.Value could be **true** OR **false** (default **false**).                                                                           |
+| `useRecaptchaDomain` | Boolean. Sets `www.recaptcha.net` as the host; useful in instances where `www.google.com` may be blocked (as detailed in the [reCaptcha docs](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally)) |
 
 **For more information, please refer to:**
 

--- a/src/interfaces/RecaptchaOptions.ts
+++ b/src/interfaces/RecaptchaOptions.ts
@@ -9,6 +9,7 @@ export interface RecaptchaOptionsV2 {
     expired_callback?: string;
     size?: string;
     tabindex?: string;
+    useRecaptchaDomain?: boolean;
 }
 export interface RecaptchaOptionsV3 {
     onload?: string;
@@ -16,4 +17,5 @@ export interface RecaptchaOptionsV3 {
     hl?: string;
     callback?: string;
     action?:string;
+    useRecaptchaDomain?: boolean;
 }

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -14,16 +14,13 @@ export class RecaptchaV2 {
   private _site_key:string;
   private _secret_key:string;
   private _options:RecaptchaOptionsV2;
-  private _alternate_host:boolean;
 
-  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV2, alternate_host?:boolean){
+  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV2){
     this._site_key = site_key
     this._secret_key = secret_key
     this._options = options || {checkremoteip:false}
-    this._alternate_host = alternate_host || false
     if (!this._site_key) throw new Error('site_key is required')
     if (!this._secret_key) throw new Error('secret_key is required')
-    if (this._alternate_host) this._api.host = this._api.alt_host
   }
   get middleware():RecaptchaMiddleware {
     return {
@@ -50,11 +47,13 @@ export class RecaptchaV2 {
     return this.renderWith({});
   }
   renderWith(optionsToOverride:RecaptchaOptionsV2){
+    let recaptcha_host = this._api.host
     let query_string = ''
     let captcha_attr = ''
 
     let options = (<any>Object).assign({},this._options, optionsToOverride);
 
+    if (options.useRecaptchaDomain) recaptcha_host = this._api.alt_host
     if (options.onload) query_string += '&onload='+options.onload
     if (options.render) query_string += '&render='+options.render
     if (options.hl) query_string += '&hl='+options.hl
@@ -66,12 +65,15 @@ export class RecaptchaV2 {
     if (options.tabindex) captcha_attr += ' data-tabindex="'+options.tabindex+'"'
   
     query_string = query_string.replace(/^&/,'?')
-    return  '<script src="//'+this._api.host+this._api.script+query_string+'" async defer></script>'+
+    return  '<script src="//'+recaptcha_host+this._api.script+query_string+'" async defer></script>'+
             '<div class="g-recaptcha" data-sitekey="'+this._site_key+'"'+captcha_attr+'></div>'
   }
   verify(req:Request, cb:(error?:string|null,data?:RecaptchaResponseDataV2|null)=>void){
     let response = null;
     let post_options = null;
+    let recaptcha_host = this._api.host
+
+    if (this._options.useRecaptchaDomain) recaptcha_host = this._api.alt_host
 
     if (!req) throw new Error('req is required');
     if(req.body && req.body['g-recaptcha-response']) response = req.body['g-recaptcha-response'];
@@ -84,7 +86,7 @@ export class RecaptchaV2 {
       if (remote_ip) query_string += '&remoteip=' + remote_ip
     }
     post_options = {
-      host: this._api.host,
+      host: recaptcha_host,
       port: '443',
       path: this._api.verify,
       method: 'POST',

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -7,22 +7,23 @@ import { RecaptchaMiddleware, RecaptchaOptionsV2, RecaptchaResponseDataV2, Recap
 export class RecaptchaV2 {
   private _api = {
     host:'www.google.com',
+    alt_host:'www.recaptcha.net',
     script:'/recaptcha/api.js',
     verify:'/recaptcha/api/siteverify'
   };
   private _site_key:string;
   private _secret_key:string;
   private _options:RecaptchaOptionsV2;
-  private _custom_host:string;
+  private _alternate_host:boolean;
 
-  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV2, custom_host?:string){
+  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV2, alternate_host?:boolean){
     this._site_key = site_key
     this._secret_key = secret_key
     this._options = options || {checkremoteip:false}
-    this._custom_host = custom_host
+    this._alternate_host = alternate_host || false
     if (!this._site_key) throw new Error('site_key is required')
     if (!this._secret_key) throw new Error('secret_key is required')
-    if (this._custom_host) this._api.host = this._custom_host
+    if (this._alternate_host) this._api.host = this._api.alt_host
   }
   get middleware():RecaptchaMiddleware {
     return {

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -13,13 +13,16 @@ export class RecaptchaV2 {
   private _site_key:string;
   private _secret_key:string;
   private _options:RecaptchaOptionsV2;
+  private _custom_host:string;
 
-  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV2){
+  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV2, custom_host?:string){
     this._site_key = site_key
     this._secret_key = secret_key
     this._options = options || {checkremoteip:false}
+    this._custom_host = custom_host
     if (!this._site_key) throw new Error('site_key is required')
     if (!this._secret_key) throw new Error('secret_key is required')
+    if (this._custom_host) this._api.host = this._custom_host
   }
   get middleware():RecaptchaMiddleware {
     return {

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -7,22 +7,23 @@ import { RecaptchaMiddleware, RecaptchaOptionsV3, RecaptchaResponseDataV3, Recap
 export class RecaptchaV3 {
   private _api = {
     host:'www.google.com',
+    alt_host:'www.recaptcha.net',
     script:'/recaptcha/api.js',
     verify:'/recaptcha/api/siteverify'
   };
   private _site_key:string;
   private _secret_key:string;
   private _options:RecaptchaOptionsV3;
-  private _custom_host:string;
+  private _alternate_host:boolean;
 
-  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV3, custom_host?:string){
+  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV3, alternate_host?:boolean){
     this._site_key = site_key
     this._secret_key = secret_key
     this._options = options || {checkremoteip:false}
-    this._custom_host = custom_host
+    this._alternate_host = alternate_host || false
     if (!this._site_key) throw new Error('site_key is required')
     if (!this._secret_key) throw new Error('secret_key is required')
-    if (this._custom_host) this._api.host = this._custom_host
+    if (this._alternate_host) this._api.host = this._api.alt_host
   }
   get middleware():RecaptchaMiddleware {
     return {

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -13,13 +13,16 @@ export class RecaptchaV3 {
   private _site_key:string;
   private _secret_key:string;
   private _options:RecaptchaOptionsV3;
+  private _custom_host:string;
 
-  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV3){
+  constructor(site_key:string, secret_key:string, options?:RecaptchaOptionsV3, custom_host?:string){
     this._site_key = site_key
     this._secret_key = secret_key
     this._options = options || {checkremoteip:false}
+    this._custom_host = custom_host
     if (!this._site_key) throw new Error('site_key is required')
     if (!this._secret_key) throw new Error('secret_key is required')
+    if (this._custom_host) this._api.host = this._custom_host
   }
   get middleware():RecaptchaMiddleware {
     return {

--- a/test/v2.spec.ts
+++ b/test/v2.spec.ts
@@ -6,6 +6,7 @@ import { HostName, HttpTestHelper } from './helpers/HttpTestHelper';
 import { RecaptchaWrapperV2 } from './helpers/RecaptchaWrapperV2';
 
 const API_URL = 'www.google.com/recaptcha/api.js'
+const ALTERNATE_API_URL = 'www.recaptcha.net/recaptcha/api.js'
 
 describe('Recaptcha v2', () => {
   let _httpTestHelper:HttpTestHelper;
@@ -168,6 +169,20 @@ describe('Recaptcha v2', () => {
       tabindex:'tabindex',
       checkremoteip:true
     });
+  })
+
+  it('Init with alternate host', () => {
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, 'www.recaptcha.net')
+    expect(recaptcha).to.be.instanceof(RecaptchaV2);
+    expect(recaptcha).to.have.property('_custom_host').equal('www.recaptcha.net');
+  })
+
+  it('Render with alternate host', () => {
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, 'www.recaptcha.net')
+    const result = recaptcha.render();
+    const expected = '<script src="//'+ALTERNATE_API_URL+'" async defer></script>'+
+    '<div class="g-recaptcha" data-sitekey="SITE_KEY"></div>'
+    expect(result).to.equal(expected)
   })
 
   it('Not init', () => {

--- a/test/v2.spec.ts
+++ b/test/v2.spec.ts
@@ -172,13 +172,13 @@ describe('Recaptcha v2', () => {
   })
 
   it('Init with alternate host', () => {
-    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, 'www.recaptcha.net')
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, true)
     expect(recaptcha).to.be.instanceof(RecaptchaV2);
-    expect(recaptcha).to.have.property('_custom_host').equal('www.recaptcha.net');
+    expect(recaptcha).to.have.property('_alternate_host').equal(true);
   })
 
   it('Render with alternate host', () => {
-    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, 'www.recaptcha.net')
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, true)
     const result = recaptcha.render();
     const expected = '<script src="//'+ALTERNATE_API_URL+'" async defer></script>'+
     '<div class="g-recaptcha" data-sitekey="SITE_KEY"></div>'

--- a/test/v2.spec.ts
+++ b/test/v2.spec.ts
@@ -172,14 +172,14 @@ describe('Recaptcha v2', () => {
   })
 
   it('Init with alternate host', () => {
-    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true})
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY',{useRecaptchaDomain:true})
     expect(recaptcha).to.be.instanceof(RecaptchaV2);
     expect(recaptcha).to.have.property('_options').that.have.property('useRecaptchaDomain').that.is.true;
 
   })
 
   it('Render with alternate host', () => {
-    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true})
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY',{useRecaptchaDomain:true})
     const result = recaptcha.render();
     const expected = '<script src="//'+ALTERNATE_API_URL+'" async defer></script>'+
     '<div class="g-recaptcha" data-sitekey="SITE_KEY"></div>'

--- a/test/v2.spec.ts
+++ b/test/v2.spec.ts
@@ -172,13 +172,14 @@ describe('Recaptcha v2', () => {
   })
 
   it('Init with alternate host', () => {
-    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, true)
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true})
     expect(recaptcha).to.be.instanceof(RecaptchaV2);
-    expect(recaptcha).to.have.property('_alternate_host').equal(true);
+    expect(recaptcha).to.have.property('_options').that.have.property('useRecaptchaDomain').that.is.true;
+
   })
 
   it('Render with alternate host', () => {
-    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {}, true)
+    let recaptcha = new RecaptchaV2('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true})
     const result = recaptcha.render();
     const expected = '<script src="//'+ALTERNATE_API_URL+'" async defer></script>'+
     '<div class="g-recaptcha" data-sitekey="SITE_KEY"></div>'

--- a/test/v3.spec.ts
+++ b/test/v3.spec.ts
@@ -161,13 +161,13 @@ describe('Recaptcha v3', () => {
   })
 
   it('Init with alternate host', () => {
-    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true, callback:'cb'})
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY',{useRecaptchaDomain:true,callback:'cb'})
     expect(recaptcha).to.be.instanceof(RecaptchaV3);
     expect(recaptcha).to.have.property('_options').that.have.property('useRecaptchaDomain').that.is.true;
   })
 
   it('Render with alternate host', () => {
-    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true, callback:'cb'})
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY',{useRecaptchaDomain:true,callback:'cb'})
     const result = recaptcha.render();
     const expected = '<script src="//'+ALTERNATE_API_URL+'?render=SITE_KEY"></script>'+
     '<script>grecaptcha.ready(function(){grecaptcha.execute(\'SITE_KEY\', {action: \'homepage\'}).then(cb);});</script>';

--- a/test/v3.spec.ts
+++ b/test/v3.spec.ts
@@ -6,6 +6,7 @@ import { HostName, HttpTestHelper } from './helpers/HttpTestHelper';
 import { RecaptchaWrapperV3 } from './helpers/RecaptchaWrapperV3';
 
 const API_URL = 'www.google.com/recaptcha/api.js'
+const ALTERNATE_API_URL = 'www.recaptcha.net/recaptcha/api.js'
 
 describe('Recaptcha v3', () => {
   let _httpTestHelper:HttpTestHelper;
@@ -157,6 +158,20 @@ describe('Recaptcha v3', () => {
       callback:'callback',
       checkremoteip:true
     });
+  })
+
+  it('Init with alternate host', () => {
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, 'www.recaptcha.net')
+    expect(recaptcha).to.be.instanceof(RecaptchaV3);
+    expect(recaptcha).to.have.property('_custom_host').equal('www.recaptcha.net');
+  })
+
+  it('Render with alternate host', () => {
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, 'www.recaptcha.net')
+    const result = recaptcha.render();
+    const expected = '<script src="//'+ALTERNATE_API_URL+'?render=SITE_KEY"></script>'+
+    '<script>grecaptcha.ready(function(){grecaptcha.execute(\'SITE_KEY\', {action: \'homepage\'}).then(cb);});</script>';
+    expect(result).to.equal(expected)
   })
 
   it('Not init', () => {

--- a/test/v3.spec.ts
+++ b/test/v3.spec.ts
@@ -161,13 +161,13 @@ describe('Recaptcha v3', () => {
   })
 
   it('Init with alternate host', () => {
-    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, true)
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true, callback:'cb'})
     expect(recaptcha).to.be.instanceof(RecaptchaV3);
-    expect(recaptcha).to.have.property('_alternate_host').equal(true);
+    expect(recaptcha).to.have.property('_options').that.have.property('useRecaptchaDomain').that.is.true;
   })
 
   it('Render with alternate host', () => {
-    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, true)
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {useRecaptchaDomain: true, callback:'cb'})
     const result = recaptcha.render();
     const expected = '<script src="//'+ALTERNATE_API_URL+'?render=SITE_KEY"></script>'+
     '<script>grecaptcha.ready(function(){grecaptcha.execute(\'SITE_KEY\', {action: \'homepage\'}).then(cb);});</script>';

--- a/test/v3.spec.ts
+++ b/test/v3.spec.ts
@@ -161,13 +161,13 @@ describe('Recaptcha v3', () => {
   })
 
   it('Init with alternate host', () => {
-    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, 'www.recaptcha.net')
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, true)
     expect(recaptcha).to.be.instanceof(RecaptchaV3);
-    expect(recaptcha).to.have.property('_custom_host').equal('www.recaptcha.net');
+    expect(recaptcha).to.have.property('_alternate_host').equal(true);
   })
 
   it('Render with alternate host', () => {
-    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, 'www.recaptcha.net')
+    let recaptcha = new RecaptchaV3('SITE_KEY','SECRET_KEY', {callback:'cb'}, true)
     const result = recaptcha.render();
     const expected = '<script src="//'+ALTERNATE_API_URL+'?render=SITE_KEY"></script>'+
     '<script>grecaptcha.ready(function(){grecaptcha.execute(\'SITE_KEY\', {action: \'homepage\'}).then(cb);});</script>';


### PR DESCRIPTION
In some instances the default reCaptcha host www.google.com may be blocked. As [detailed in the reCaptcha FAQ](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally), the recommendation is to use the alternate host www.recaptcha.net in these situations.

This PR provides the ability to do so, via an optional `CUSTOM_HOST` parameter.